### PR TITLE
Add Codex MCP wiring script and README for pmll-memory-mcp

### DIFF
--- a/CODEX_MCP_SETUP.md
+++ b/CODEX_MCP_SETUP.md
@@ -1,0 +1,53 @@
+# Codex MCP wiring for `pmll-memory-mcp`
+
+This repository includes a helper script to wire the `pmll-memory-mcp` server into Codex's MCP configuration.
+
+## Prerequisites
+
+- Python 3.11+ with `pmll-memory-mcp` installed.
+- Codex client configured on your machine.
+
+## Preferred (CLI) wiring
+
+If you have the Codex CLI, run:
+
+```bash
+./scripts/wire_codex_pmll_memory_mcp.sh cli
+```
+
+This runs the equivalent of:
+
+```bash
+codex mcp remove pmllMemory
+codex mcp add pmllMemory /path/to/python -m pmll_memory_mcp.server
+```
+
+## Fallback (direct config file)
+
+If CLI is unavailable:
+
+```bash
+./scripts/wire_codex_pmll_memory_mcp.sh file
+```
+
+`auto` mode (default) will use CLI if available, else file mode:
+
+```bash
+./scripts/wire_codex_pmll_memory_mcp.sh
+```
+
+The file mode writes/updates this block in `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.pmllMemory]
+command = "/path/to/python"
+args = ["-m", "pmll_memory_mcp.server"]
+```
+
+## Verify
+
+```bash
+codex mcp list
+```
+
+You should see `pmllMemory` listed.

--- a/CODEX_MCP_SETUP.md
+++ b/CODEX_MCP_SETUP.md
@@ -6,6 +6,7 @@ This repository includes a helper script to wire the `pmll-memory-mcp` server in
 
 - Python 3.11+ with `pmll-memory-mcp` installed.
 - Codex client configured on your machine.
+- `uv >= 0.8.6` if you want to run the same validation workflow used in CI.【flo_ai/pyproject.toml sets this requirement】
 
 ## Preferred (CLI) wiring
 
@@ -44,10 +45,20 @@ command = "/path/to/python"
 args = ["-m", "pmll_memory_mcp.server"]
 ```
 
-## Verify
+## Verify MCP wiring
 
 ```bash
 codex mcp list
 ```
 
 You should see `pmllMemory` listed.
+
+## Optional: run package validation tests
+
+```bash
+export PATH=$HOME/.local/bin:$PATH
+cd flo_ai
+uv sync
+uv build
+uv run pytest -m "not (integration)"
+```

--- a/CODEX_MCP_SETUP.md
+++ b/CODEX_MCP_SETUP.md
@@ -4,9 +4,22 @@ This repository includes a helper script to wire the `pmll-memory-mcp` server in
 
 ## Prerequisites
 
-- Python 3.11+ with `pmll-memory-mcp` installed.
+- Python 3.11+.
 - Codex client configured on your machine.
-- `uv >= 0.8.6` if you want to run the same validation workflow used in CI.【flo_ai/pyproject.toml sets this requirement】
+- `pmll-memory-mcp` installed in the same Python environment used for the MCP command.
+- `uv >= 0.8.6` if you want to run the same validation workflow used in CI.
+
+## Install `pmll-memory-mcp`
+
+Install from PyPI:
+
+```bash
+python -m pip install pmll-memory-mcp
+```
+
+### About `https://github.com/drqsatoshi/Pmll.git`
+
+That repository currently does **not** contain Python packaging metadata (`pyproject.toml` or `setup.py`), so `pip install git+https://github.com/drqsatoshi/Pmll.git` fails. Use the PyPI package command above unless that repo adds packaging files.
 
 ## Preferred (CLI) wiring
 

--- a/scripts/wire_codex_pmll_memory_mcp.sh
+++ b/scripts/wire_codex_pmll_memory_mcp.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVER_NAME="pmllMemory"
+METHOD="${1:-auto}" # auto | cli | file
+
+resolve_python_bin() {
+  local candidate="${PYTHON_BIN:-}"
+  if [[ -n "$candidate" ]]; then
+    echo "$candidate"
+    return 0
+  fi
+
+  if command -v pyenv >/dev/null 2>&1; then
+    candidate="$(pyenv root)/versions/3.11.14/bin/python"
+    if [[ -x "$candidate" ]]; then
+      echo "$candidate"
+      return 0
+    fi
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    command -v python3
+    return 0
+  fi
+
+  if command -v python >/dev/null 2>&1; then
+    command -v python
+    return 0
+  fi
+
+  return 1
+}
+
+wire_with_cli() {
+  local python_bin="$1"
+  codex mcp remove "$SERVER_NAME" >/dev/null 2>&1 || true
+  codex mcp add "$SERVER_NAME" "$python_bin" -m pmll_memory_mcp.server
+  echo "Configured Codex MCP server '${SERVER_NAME}' using Codex CLI"
+  echo "Using command: ${python_bin} -m pmll_memory_mcp.server"
+}
+
+wire_with_file() {
+  local python_bin="$1"
+  local config_dir="${HOME}/.codex"
+  local config_path="${config_dir}/config.toml"
+
+  mkdir -p "$config_dir"
+
+  local tmp_file
+  tmp_file="$(mktemp)"
+  if [[ -f "$config_path" ]]; then
+    cp "$config_path" "$tmp_file"
+  else
+    : > "$tmp_file"
+  fi
+
+  python3 - "$tmp_file" "$SERVER_NAME" "$python_bin" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+config_path = Path(sys.argv[1])
+server_name = sys.argv[2]
+python_bin = sys.argv[3]
+
+text = config_path.read_text(encoding="utf-8")
+pattern = re.compile(rf"(?ms)^\[mcp_servers\.{re.escape(server_name)}\]\n.*?(?=^\[|\Z)")
+block = (
+    f"[mcp_servers.{server_name}]\n"
+    f"command = \"{python_bin}\"\n"
+    "args = [\"-m\", \"pmll_memory_mcp.server\"]\n"
+)
+
+if pattern.search(text):
+    text = pattern.sub(block + "\n", text).rstrip() + "\n"
+else:
+    if text and not text.endswith("\n"):
+        text += "\n"
+    text += "\n" + block
+
+config_path.write_text(text, encoding="utf-8")
+print(f"Wrote MCP server '{server_name}' to {config_path}")
+PY
+
+  mv "$tmp_file" "$config_path"
+
+  echo "Configured Codex MCP server '${SERVER_NAME}' in ${config_path}"
+  echo "Using command: ${python_bin} -m pmll_memory_mcp.server"
+}
+
+main() {
+  local python_bin
+  python_bin="$(resolve_python_bin)" || {
+    echo "Could not determine a runnable Python binary." >&2
+    exit 1
+  }
+
+  if [[ ! -x "$python_bin" ]]; then
+    echo "Resolved Python binary is not executable: $python_bin" >&2
+    exit 1
+  fi
+
+  case "$METHOD" in
+    auto)
+      if command -v codex >/dev/null 2>&1; then
+        wire_with_cli "$python_bin"
+      else
+        wire_with_file "$python_bin"
+      fi
+      ;;
+    cli)
+      if ! command -v codex >/dev/null 2>&1; then
+        echo "codex CLI not found. Install Codex CLI or run: $0 file" >&2
+        exit 1
+      fi
+      wire_with_cli "$python_bin"
+      ;;
+    file)
+      wire_with_file "$python_bin"
+      ;;
+    *)
+      echo "Usage: $0 [auto|cli|file]" >&2
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/wire_codex_pmll_memory_mcp.sh
+++ b/scripts/wire_codex_pmll_memory_mcp.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 SERVER_NAME="pmllMemory"
+PMLL_REPO_URL="https://github.com/drqsatoshi/Pmll.git"
 METHOD="${1:-auto}" # auto | cli | file
 
 resolve_python_bin() {
@@ -30,6 +31,17 @@ resolve_python_bin() {
   fi
 
   return 1
+}
+
+ensure_pmll_installed() {
+  local python_bin="$1"
+
+  if ! "$python_bin" -c "import pmll_memory_mcp" >/dev/null 2>&1; then
+    echo "pmll_memory_mcp is not installed for: $python_bin" >&2
+    echo "Install one of the following:" >&2
+    echo "  $python_bin -m pip install pmll-memory-mcp" >&2
+    exit 1
+  fi
 }
 
 wire_with_cli() {
@@ -100,6 +112,8 @@ main() {
     echo "Resolved Python binary is not executable: $python_bin" >&2
     exit 1
   fi
+
+  ensure_pmll_installed "$python_bin"
 
   case "$METHOD" in
     auto)


### PR DESCRIPTION
### Motivation

- Provide an easy way to register the `pmll-memory-mcp` server with Codex MCP configuration either via the Codex CLI or by updating the config file. 
- Make installation and verification explicit so users can quickly wire local MCP servers into the Codex client.

### Description

- Add `scripts/wire_codex_pmll_memory_mcp.sh`, a bash helper that discovers a Python binary and wires the MCP server using either the Codex CLI (`codex mcp add/remove`) or by updating `~/.codex/config.toml` depending on the `auto|cli|file` mode. 
- Implement `resolve_python_bin` to prefer `$PYTHON_BIN`, then `pyenv` 3.11, then `python3`/`python`, and validate executability before proceeding. 
- Implement `wire_with_file` which safely updates the TOML config using a temporary file and an embedded Python snippet to insert or replace the `[mcp_servers.pmllMemory]` block. 
- Add `CODEX_MCP_SETUP.md` documenting prerequisites, CLI/file wiring commands, `auto` behavior, and a verification step with `codex mcp list`.

### Testing

- No automated tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4b78a7e84832181cc19f52f9deb95)